### PR TITLE
enabled /dev/video0 for docker

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-sudo docker run -it --rm --net=host --runtime nvidia -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v $HOME/github/ex-transformers:/root/ex-transformers:rw -v /tmp/.X11-unix/:/tmp/.X11-unix ex-transformer:100
+sudo docker run -it --rm --net=host --runtime nvidia -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 \
+	-v $HOME/github/ex-transformers:/root/ex-transformers:rw -v /tmp/.X11-unix/:/tmp/.X11-unix \
+	--device /dev/snd \
+	--device /dev/bus/usb \
+	--device /dev/video0:/dev/video0:mwr \
+ex-transformer:100

--- a/obj_detection.py
+++ b/obj_detection.py
@@ -179,9 +179,13 @@ def detect_for_video():
         ret, cvimg = cap.read()
         if cvimg is None:
             break
-
+        print(f"{cvimg.shape=}")
+        if cvimg.shape[0] > 640:
+            H, W = cvimg.shape[:2]
+            cvimg = cv2.resize(cvimg, (W // 2 , H // 2))
         image = cv2pil(cvimg)
         result = object_detector(image)
+        print(f"{len(result)=}")
         oimage = draw_detection(cvimg, result)
         cv2.imshow("transformers", oimage)
         key = cv2.waitKey(1)

--- a/obj_detection.py
+++ b/obj_detection.py
@@ -103,6 +103,8 @@ _COLORS_UINT8 = (255 * _COLORS).astype(np.uint8)
 
 LABEL2NUM = get_label2num_dict()
 
+MODEL = "devonho/detr-resnet-50_finetuned_cppe5"
+
 def draw_detection(image, result):
     for i, d in enumerate(result):
         xmin = d["box"]["xmin"]
@@ -153,7 +155,7 @@ def detect_url_image(url):
     image = Image.open(image_data)
 
     # Allocate a pipeline for object detection
-    object_detector = pipeline('object-detection')
+    object_detector = pipeline('object-detection', model=MODEL)
     result = object_detector(image)
     print(result)
     cvimg = pil2cv(image)
@@ -164,7 +166,7 @@ def detect_image(imgname):
     image = Image.open(imgname)
 
     # Allocate a pipeline for object detection
-    object_detector = pipeline('object-detection')
+    object_detector = pipeline('object-detection', model=MODEL)
     result = object_detector(image)
     print(result)
     cvimg = pil2cv(image)
@@ -172,7 +174,7 @@ def detect_image(imgname):
     cv2.imwrite("junk.jpg", oimage)
 
 def detect_for_video():
-    object_detector = pipeline('object-detection')
+    object_detector = pipeline('object-detection', model=MODEL)
     cap = cv2.VideoCapture(0)
     cv2.namedWindow("transformers", cv2.WINDOW_NORMAL)
     while True:


### PR DESCRIPTION
# what
- dockerの起動時に`/dev/video0`を使えるようにする記述を追加。
- python3 obj_detection.py --video /dev/video0 のときに画像が表示されることを確認。
# TODO:
- まだ、実行時には課題が残る。
- 検出結果が空である。
